### PR TITLE
Also build ptdump_static by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SDIR=src
 _OBJ = cfg.o disassembler.o tnt_cache.o decoder.o libxdc.o mmh3.o trace_cache.o
 OBJ = $(patsubst %,$(ODIR)/%,$(_OBJ))
 
-default: libxdc.so libxdc.a ptdump
+default: libxdc.so libxdc.a ptdump ptdump_static
 
 $(ODIR)/%.o: $(SDIR)/%.c $(SDIR)/*.h libxdc.h
 	mkdir -p build


### PR DESCRIPTION
We need this for the kAFL coverage in our setup at https://github.com/intel/ccc-linux-guest-hardening. 