### PR TITLE
test: add missing fcntl header

### DIFF
--- a/test/page_cache.c
+++ b/test/page_cache.c
@@ -35,6 +35,7 @@ SOFTWARE.
 #include <stdio.h>
 #include <sys/mman.h>
 #include <assert.h>
+#include <fcntl.h>
 #include "page_cache.h"
 
 


### PR DESCRIPTION
Add missing `#include <fcntl.h>`, triggered during a compilation on Alpine distribution
![image](https://user-images.githubusercontent.com/964610/200583441-dd2f43bb-9d3b-4266-807a-c3d2d959ec1a.png)
